### PR TITLE
Fix "Receipient" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ func main() {
 
 ```
 
-### Adding Receipients
+### Adding Recipients
 
 ```Go
 message := sendgrid.NewMail()
@@ -52,9 +52,9 @@ address, _ := mail.ParseAddress("Example <example@sendgrid.com>")
 message.AddReceipient(address) // Receives a vaild mail.Address
 ```
 
-### Adding BCC Receipients
+### Adding BCC Recipients
 
-Same concept as regular receipients excepts the methods are:
+Same concept as regular recipient excepts the methods are:
 
 *   AddBCC
 *   AddReceipientBCC

--- a/sendgrid_mail.go
+++ b/sendgrid_mail.go
@@ -4,6 +4,7 @@ import (
 	"github.com/elbuo8/smtpmail"
 	"github.com/sendgrid/smtpapi-go"
 	"io/ioutil"
+	"net/mail"
 	"path/filepath"
 )
 
@@ -27,4 +28,12 @@ func (m *SGMail) AddAttachment(filePath string) error {
 	_, filename := filepath.Split(filePath)
 	m.Files[filename] = string(file)
 	return nil
+}
+
+func (m *SGMail) AddRecipient(email *mail.Address) {
+	m.Mail.AddReceipient(email)
+}
+
+func (m *SGMail) AddRecipientBCC(email *mail.Address) {
+	m.Mail.AddReceipientBCC(email)
 }

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -11,7 +11,7 @@ func Test_Send(t *testing.T) {
 	message := NewMail()
 	message.AddTo("Yamil Asusta <yamil.asusta@sendgrid.com>")
 	address, _ := mail.ParseAddress("Yamil Asusta <yamil.asusta@upr.edu>")
-	message.AddReceipient(address)
+	message.AddRecipient(address)
 	message.AddSubject("SendGrid Testing")
 	message.AddHTML("WIN")
 	message.AddFrom("yamil@sendgrid.com")


### PR DESCRIPTION
Correct spelling is "Recipient"
