### PR TITLE
Error checking should be done before Response checking

### DIFF
--- a/sendgrid.go
+++ b/sendgrid.go
@@ -88,12 +88,13 @@ func (sg *SGClient) Send(m *SGMail) error {
 		return e
 	}
 	r, e := sg.Client.PostForm(sg.APIMail, values)
-	if e == nil { // errors can contain nil Body responses
-		defer r.Body.Close()
+	if e != nil {
+		return fmt.Errorf("sendgrid.go: error:%v; response:%v", e, r)
 	}
-	if r.StatusCode == http.StatusOK && e == nil {
+	if r.StatusCode == http.StatusOK {
 		return nil
 	}
 	body, _ := ioutil.ReadAll(r.Body)
+	r.Body.Close()
 	return fmt.Errorf("sendgrid.go: code:%d error:%v body:%s", r.StatusCode, e, body)
 }


### PR DESCRIPTION
When there is an error then response object can be `nil`. We should check errors before we do any operation on response object.
