### PR TITLE
Make sure to defer the closing of the body

### DIFF
--- a/sendgrid.go
+++ b/sendgrid.go
@@ -91,10 +91,14 @@ func (sg *SGClient) Send(m *SGMail) error {
 	if e != nil {
 		return fmt.Errorf("sendgrid.go: error:%v; response:%v", e, r)
 	}
+	
+	defer r.Body.Close()
+	
 	if r.StatusCode == http.StatusOK {
 		return nil
 	}
+	
 	body, _ := ioutil.ReadAll(r.Body)
-	r.Body.Close()
+	
 	return fmt.Errorf("sendgrid.go: code:%d error:%v body:%s", r.StatusCode, e, body)
 }


### PR DESCRIPTION
Hello, I just noticed this detail: The way the code currently was, if the PostForm successfully goes through and the http status == http.StatusOK, then you early return nil.  This means the r.Body.Close() never ran in the successful case.
