### PR TITLE
Modified TestSend in sendgrid_test.go to check return value of Send

### DIFF
--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -30,5 +30,8 @@ func TestSend(t *testing.T) {
 	m.AddTo("Test! <test@email.com>")
 	m.SetSubject("Test")
 	m.SetText("Text")
-	client.Send(m)
+
+	if e := client.Send(m); e != nil {
+		t.Errorf("Send failed to send email. Returned error: %v", e)
+	}
 }


### PR DESCRIPTION
In sendgrid_test.go, TestSend does not verify whether the call to Send returns nil or not. Hence, TestSend will never fail even if a non nil value is returned. 

The changes I've made simply verifies whether the value returned by Send is nil or not. If nil is returned then Send was successful. If not, t.Errorf is called accordingly and displays the returned error message. 

Please let me know if you'd like me to change the output of Errorf. 
