### PR TITLE
Matched BCC method to match SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ message.AddRecipient(address) // Receives a vaild mail.Address
 Same concept as regular recipient excepts the methods are:
 
 *   AddBCC
-*   AddRecipientBCC
+*   AddBccRecipient
 
 ### Setting the Subject
 


### PR DESCRIPTION
https://github.com/sendgrid/sendgrid-go/blob/master/mail.go#L168 

Changed to AddBccRecipient instead of AddRecipientBCC
