### PR TITLE
Use default transport to close connections, set timeout at client

### DIFF
--- a/sendgrid.go
+++ b/sendgrid.go
@@ -4,7 +4,6 @@ package sendgrid
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -12,10 +11,6 @@ import (
 )
 
 const Version = "1.1.0"
-
-func timeoutHandler(network, address string) (net.Conn, error) {
-	return net.DialTimeout(network, address, time.Duration(5*time.Second))
-}
 
 // SGClient will contain the credentials and default values
 type SGClient struct {
@@ -81,11 +76,9 @@ func (sg *SGClient) buildURL(m *SGMail) (url.Values, error) {
 // Send will send mail using SG web API
 func (sg *SGClient) Send(m *SGMail) error {
 	if sg.Client == nil {
-		transport := http.Transport{
-			Dial: timeoutHandler,
-		}
 		sg.Client = &http.Client{
-			Transport: &transport,
+			Transport: http.DefaultTransport,
+			Timeout:   5 * time.Second,
 		}
 	}
 	var e error


### PR DESCRIPTION
Using current master under go version go1.3.1 linux/amd64, we found that many connections to sendgrid were being orphaned in a `CLOSE_WAIT` state, leading to file descriptors that are never released. We traced the issue to the use of a custom Transport to implement dial timeouts not setting deadlines on other TCP operations (read, write, etc). This PR uses the Client.Timeout field to let the stdlib handle the timing out of connections, while using the DefaultTransport so that other transport defaults are set.

The issue presents itself as thousands of `CLOSE_WAIT` connections to sendgrid when checking `lsof -l`
```
emails TCP ip-10-171-52-54.ec2.internal:39976->184.173.190.226-static.reverse.softlayer.com:https (CLOSE_WAIT)
emails TCP ip-10-171-52-54.ec2.internal:59229->184.173.190.227-static.reverse.softlayer.com:https (CLOSE_WAIT)
emails TCP ip-10-171-52-54.ec2.internal:39978->184.173.190.226-static.reverse.softlayer.com:https (CLOSE_WAIT)
emails TCP ip-10-171-52-54.ec2.internal:40039->184.173.190.226-static.reverse.softlayer.com:https (CLOSE_WAIT)
emails TCP ip-10-171-52-54.ec2.internal:59292->184.173.190.227-static.reverse.softlayer.com:https (CLOSE_WAIT)
emails TCP ip-10-171-52-54.ec2.internal:40041->184.173.190.226-static.reverse.softlayer.com:https (CLOSE_WAIT)
emails TCP ip-10-171-52-54.ec2.internal:59294->184.173.190.227-static.reverse.softlayer.com:https (CLOSE_WAIT)
emails TCP ip-10-171-52-54.ec2.internal:40043->184.173.190.226-static.reverse.softlayer.com:https (CLOSE_WAIT)
```

With this patch, the connections are properly closed after the request is finished and no such entries can be found.

The Client.Timeout field was added in Go 1.3, so I think the travis build will fail for Go 1.1. Please advise if a Go 1.1 solution is necessary as well.