### PR TITLE
PR Addressing Issue #27 of Simplifying the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] - 2015-6-09
+### Changed
+- Singular-verion functions in mail.go such as AddTo(), which used to take strings and mail.Address, have been switched to variadic parameters to allow users to pass single or multiple parameters using the same function, simplifying the API.
+
 ## [2.0.0] - 2015-5-02
 ### Changed
 - Fixed a nasty bug with orphaned connections but drops support for Go versions < 1.3. Thanks [trinchan](https://github.com/sendgrid/sendgrid-go/pull/24)

--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ If you wish to use the X-SMTPAPI on your own app, you can use the [SMTPAPI Go li
 ```go
 message.SMTPAPIHeader.AddTo("addTo@mailinator.com")
 // or
-tos := []string{"test@test.com", "test@email.com"}
-message.SMTPAPIHeader.AddTos(tos)
+message.SMTPAPIHeader.AddTo("test@test.com", "test@email.com")
 // or
 message.SMTPAPIHeader.SetTos(tos)
 ```

--- a/mail.go
+++ b/mail.go
@@ -35,38 +35,37 @@ func NewMail() *SGMail {
 }
 
 // AddTo adds a valid email address
-func (m *SGMail) AddTo(email string) error {
-	address, err := mail.ParseAddress(email)
-	if err != nil {
-		return err
+func (m *SGMail) AddTo(emails ...string) error {
+	for i := 0; i < len(emails); i++ {
+		address, err := mail.ParseAddress(emails[i])
+		if err != nil {
+			return err
+		}
+		m.AddRecipient(address)
 	}
-	m.AddRecipient(address)
 	return nil
 }
 
 // AddTos adds multiple email addresses
+// Deprecated
 func (m *SGMail) AddTos(emails []string) error {
-	for i := 0; i < len(emails); i++ {
-		if err := m.AddTo(emails[i]); err != nil {
-			return err
-		}
-	}
-	return nil
+	return m.AddTo(emails...)
 }
 
 // AddRecipient will add mail.Address emails to recipients.
-func (m *SGMail) AddRecipient(recipient *mail.Address) {
-	m.To = append(m.To, recipient.Address)
-	if recipient.Name != "" {
-		m.ToName = append(m.ToName, recipient.Name)
+func (m *SGMail) AddRecipient(recipients ...*mail.Address) {
+	for i := 0; i < len(recipients); i++ {
+		m.To = append(m.To, recipients[i].Address)
+		if recipients[i].Name != "" {
+			m.ToName = append(m.ToName, recipients[i].Name)
+		}
 	}
 }
 
 // AddRecipients calls AddRecipient per email
+// Deprecated
 func (m *SGMail) AddRecipients(recipients []*mail.Address) {
-	for i := 0; i < len(recipients); i++ {
-		m.AddRecipient(recipients[i])
-	}
+	m.AddRecipient(recipients...)
 }
 
 // AddToName sets the "pretty" name for a recipient
@@ -80,35 +79,34 @@ func (m *SGMail) AddToNames(names []string) {
 }
 
 // AddCc ...
-func (m *SGMail) AddCc(cc string) error {
-	address, err := mail.ParseAddress(cc)
-	if err != nil {
-		return err
+func (m *SGMail) AddCc(ccs ...string) error {
+	for i := 0; i < len(ccs); i++ {
+		address, err := mail.ParseAddress(ccs[i])
+		if err != nil {
+			return err
+		}
+		m.AddCcRecipient(address)
 	}
-	m.AddCcRecipient(address)
 	return nil
 }
 
 // AddCcs ...
+// Deprecated
 func (m *SGMail) AddCcs(ccs []string) error {
-	for i := 0; i < len(ccs); i++ {
-		if err := m.AddCc(ccs[i]); err != nil {
-			return err
-		}
-	}
-	return nil
+	return m.AddCc(ccs...)
 }
 
 // AddCcRecipient ...
-func (m *SGMail) AddCcRecipient(recipient *mail.Address) {
-	m.Cc = append(m.Cc, recipient.Address)
+func (m *SGMail) AddCcRecipient(recipients ...*mail.Address) {
+	for i := 0; i < len(recipients); i++ {
+		m.Cc = append(m.Cc, recipients[i].Address)
+	}
 }
 
 // AddCcRecipients ...
+// Deprecated
 func (m *SGMail) AddCcRecipients(recipients []*mail.Address) {
-	for i := 0; i < len(recipients); i++ {
-		m.AddCcRecipient(recipients[i])
-	}
+	m.AddCcRecipient(recipients...)
 }
 
 // SetSubject sets the email's subject
@@ -145,35 +143,35 @@ func (m *SGMail) SetFromEmail(address *mail.Address) {
 }
 
 // AddBcc ...
-func (m *SGMail) AddBcc(bcc string) error {
-	address, err := mail.ParseAddress(bcc)
-	if err != nil {
-		return err
+func (m *SGMail) AddBcc(bccs ...string) error {
+	for i := 0; i < len(bccs); i++ {
+		address, err := mail.ParseAddress(bccs[i])
+		if err != nil {
+			return err
+		}
+		m.AddBccRecipient(address)
 	}
-	m.AddBccRecipient(address)
 	return nil
 }
 
 // AddBccs ...
+// Deprecated
 func (m *SGMail) AddBccs(bccs []string) error {
-	for i := 0; i < len(bccs); i++ {
-		if err := m.AddBcc(bccs[i]); err != nil {
-			return err
-		}
-	}
-	return nil
+	return m.AddBcc(bccs...)
 }
 
 // AddBccRecipient ...
-func (m *SGMail) AddBccRecipient(recipient *mail.Address) {
-	m.Bcc = append(m.Bcc, recipient.Address)
+func (m *SGMail) AddBccRecipient(recipients ...*mail.Address) {
+	for i := 0; i < len(recipients); i++ {
+		m.Bcc = append(m.Bcc, recipients[i].Address)
+	}
+
 }
 
 // AddBccRecipients ...
+// Deprecated
 func (m *SGMail) AddBccRecipients(recipients []*mail.Address) {
-	for i := 0; i < len(recipients); i++ {
-		m.AddBccRecipient(recipients[i])
-	}
+	m.AddBccRecipient(recipients...)
 }
 
 // SetFromName ...

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const Version = "2.0.0"
+const Version = "2.1.0"
 
 // SGClient will contain the credentials and default values
 type SGClient struct {

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -13,7 +13,7 @@ const (
 )
 
 func TestSendGridVersion(t *testing.T) {
-	if Version != "2.0.0" {
+	if Version != "2.1.0" {
 		t.Error("SendGrid version does not match")
 	}
 }


### PR DESCRIPTION
All "singular" functions in mail.go have been switch to use variadic parameters so that users can pass one or multiple values rather than having to switch between the singular and plural versions of that function.

Changes made to mail.go are entirely backwards compatible.