### PR TITLE
ParseAddress fails on non ascii characters

### DIFF
--- a/mail.go
+++ b/mail.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sendgrid/smtpapi-go"
+	twmail "github.com/teamwork/utils/mail"
 )
 
 // SGMail is representation of a valid SendGrid Mail
@@ -36,7 +37,7 @@ func NewMail() *SGMail {
 
 // AddTo adds a valid email address
 func (m *SGMail) AddTo(email string) error {
-	address, err := mail.ParseAddress(email)
+	address, err := twmail.ParseAddress(email)
 	if err != nil {
 		return err
 	}
@@ -81,7 +82,7 @@ func (m *SGMail) AddToNames(names []string) {
 
 // AddCc ...
 func (m *SGMail) AddCc(cc string) error {
-	address, err := mail.ParseAddress(cc)
+	address, err := twmail.ParseAddress(cc)
 	if err != nil {
 		return err
 	}
@@ -128,7 +129,7 @@ func (m *SGMail) SetHTML(html string) {
 
 // SetFrom will set the senders email property
 func (m *SGMail) SetFrom(from string) error {
-	address, err := mail.ParseAddress(from)
+	address, err := twmail.ParseAddress(from)
 	if err != nil {
 		return err
 	}
@@ -146,7 +147,7 @@ func (m *SGMail) SetFromEmail(address *mail.Address) {
 
 // AddBcc ...
 func (m *SGMail) AddBcc(bcc string) error {
-	address, err := mail.ParseAddress(bcc)
+	address, err := twmail.ParseAddress(bcc)
 	if err != nil {
 		return err
 	}
@@ -183,7 +184,7 @@ func (m *SGMail) SetFromName(fromname string) {
 
 // SetReplyTo ...
 func (m *SGMail) SetReplyTo(replyto string) error {
-	address, err := mail.ParseAddress(replyto)
+	address, err := twmail.ParseAddress(replyto)
 	if err != nil {
 		return err
 	}

--- a/mail_test.go
+++ b/mail_test.go
@@ -7,6 +7,8 @@ import (
 	"net/mail"
 	"testing"
 	"time"
+
+	twmail "github.com/teamwork/utils/mail"
 )
 
 func TestNewMail(t *testing.T) {
@@ -152,7 +154,7 @@ func TestSetHTML(t *testing.T) {
 
 func TestSetFrom(t *testing.T) {
 	m := NewMail()
-	testFrom, _ := mail.ParseAddress("Joe <email@email.com>")
+	testFrom, _ := twmail.ParseAddress("Joe <email@email.com>")
 	m.SetFrom(testFrom.String())
 	switch {
 	case m.From != testFrom.Address:

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -22,27 +22,20 @@ type SGClient struct {
 
 // NewSendGridClient will return a new SGClient. Used for username and password
 func NewSendGridClient(apiUser, apiKey string) *SGClient {
-	apiMail := "https://api.sendgrid.com/api/mail.send.json?"
-
-	Client := &SGClient{
+	return &SGClient{
 		apiUser: apiUser,
 		apiPwd:  apiKey,
-		APIMail: apiMail,
+		APIMail: "https://api.sendgrid.com/api/mail.send.json?",
+		Client: &http.Client{
+			Transport: http.DefaultTransport,
+			Timeout:   5 * time.Second,
+		},
 	}
-
-	return Client
 }
 
 // NewSendGridClient will return a new SGClient. Used for api key
 func NewSendGridClientWithApiKey(apiKey string) *SGClient {
-	apiMail := "https://api.sendgrid.com/api/mail.send.json?"
-
-	Client := &SGClient{
-		apiPwd:  apiKey,
-		APIMail: apiMail,
-	}
-
-	return Client
+	return NewSendGridClient("", apiKey)
 }
 
 func (sg *SGClient) buildURL(m *SGMail) (url.Values, error) {
@@ -92,12 +85,6 @@ func (sg *SGClient) buildURL(m *SGMail) (url.Values, error) {
 
 // Send will send mail using SG web API
 func (sg *SGClient) Send(m *SGMail) error {
-	if sg.Client == nil {
-		sg.Client = &http.Client{
-			Transport: http.DefaultTransport,
-			Timeout:   5 * time.Second,
-		}
-	}
 	var e error
 	values, e := sg.buildURL(m)
 	if e != nil {


### PR DESCRIPTION
We have found an issue where legitimate e-mail addresses with non ascii names are rejected by ParseAddress.  There are several work-arounds, this PR being one of them.   View the changes that we have made here - https://github.com/Teamwork/utils/blob/master/mail/parse.go