### PR TITLE
Send a Single Email to a Single Recipient

### DIFF
--- a/helpers/mail/mail_v3.go
+++ b/helpers/mail/mail_v3.go
@@ -511,6 +511,12 @@ func NewEmail(name string, address string) *Email {
 	}
 }
 
+func NewSingleEmail(from *Email, subject string, to *Email, plainTextContent string, htmlContent string) *SGMailV3 {
+	plainText := NewContent("text", plainTextContent)
+	html := NewContent("html", htmlContent)
+	return NewV3MailInit(from, subject, to, plainText, html)
+}
+
 func NewContent(contentType string, value string) *Content {
 	return &Content{
 		Type:  contentType,

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -878,6 +878,32 @@ func TestV3NewEmail(t *testing.T) {
 	}
 }
 
+func TestV3NewSingleEmail(t *testing.T) {
+	from := NewEmail("Example User", "test@example.com")
+	subject := "Hello World from the SendGrid Go Library"
+	to := NewEmail("Example User", "test@example.com")
+	plainTextContent := "some text here"
+	htmlContent := "<strong>some HTML content</strong>"
+
+	m := NewSingleEmail(from, subject, to, plainTextContent, htmlContent)
+
+	if m == nil {
+		t.Errorf("NewV3MailInit() shouldn't return nil")
+	}
+
+	if m.From == nil {
+		t.Errorf("From shouldn't be nil")
+	}
+
+	if m.Subject != subject {
+		t.Errorf("Subject should be %s, got %s", subject, m.Subject)
+	}
+
+	if m.Content == nil {
+		t.Errorf("Content shouldn't be nil")
+	}
+}
+
 func TestV3NewClickTrackingSetting(t *testing.T) {
 	c := NewClickTrackingSetting()
 	c.SetEnable(true)

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -1,10 +1,17 @@
 // Package sendgrid provides a simple interface to interact with the SendGrid API
 package sendgrid
 
-import "github.com/sendgrid/rest" // depends on version 2.2.0
+import (
+	"github.com/sendgrid/rest" // depends on version 2.2.0
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+)
 
 // Version is this client library's current version
 const Version = "3.1.0"
+
+type Client struct {
+	rest.Request
+}
 
 // GetRequest returns a default request object.
 func GetRequest(key string, endpoint string, host string) rest.Request {
@@ -21,6 +28,17 @@ func GetRequest(key string, endpoint string, host string) rest.Request {
 		Headers: requestHeaders,
 	}
 	return request
+}
+
+func (cl *Client) Send(email *mail.SGMailV3) (*rest.Response, error) {
+	cl.Body = mail.GetRequestBody(email)
+	return API(cl.Request)
+}
+
+func NewSendClient(key string) *Client {
+	request := GetRequest(key, "/v3/mail/send", "")
+	request.Method = "POST"
+	return &Client{request}
 }
 
 // DefaultClient is used if no custom HTTP client is defined

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -1938,6 +1938,159 @@ func Test_test_mail_batch__batch_id__get(t *testing.T) {
 	}
 }
 
+func Test_test_send_client(t *testing.T) {
+	apiKey := "SENDGRID_APIKEY"
+	client := NewSendClient(apiKey)
+	// override the base url for test purposes
+	client.Request.BaseURL = "http://localhost:4010/v3/mail/send"
+	client.Request.Body = []byte(` {
+		"asm": {
+			"group_id": 1,
+			"groups_to_display": [
+			1,
+			2,
+			3
+			]
+		},
+		"attachments": [
+			{
+			"content": "[BASE64 encoded content block here]",
+			"content_id": "ii_139db99fdb5c3704",
+			"disposition": "inline",
+			"filename": "file1.jpg",
+			"name": "file1",
+			"type": "jpg"
+			}
+		],
+		"batch_id": "[YOUR BATCH ID GOES HERE]",
+		"categories": [
+			"category1",
+			"category2"
+		],
+		"content": [
+			{
+			"type": "text/html",
+			"value": "<html><p>Hello, world!</p><img src=[CID GOES HERE]></img></html>"
+			}
+		],
+		"custom_args": {
+			"New Argument 1": "New Value 1",
+			"activationAttempt": "1",
+			"customerAccountNumber": "[CUSTOMER ACCOUNT NUMBER GOES HERE]"
+		},
+		"from": {
+			"email": "sam.smith@example.com",
+			"name": "Sam Smith"
+		},
+		"headers": {},
+		"ip_pool_name": "[YOUR POOL NAME GOES HERE]",
+		"mail_settings": {
+			"bcc": {
+			"email": "ben.doe@example.com",
+			"enable": true
+			},
+			"bypass_list_management": {
+			"enable": true
+			},
+			"footer": {
+			"enable": true,
+			"html": "<p>Thanks</br>The SendGrid Team</p>",
+			"text": "Thanks,/n The SendGrid Team"
+			},
+			"sandbox_mode": {
+			"enable": false
+			},
+			"spam_check": {
+			"enable": true,
+			"post_to_url": "http://example.com/compliance",
+			"threshold": 3
+			}
+		},
+		"personalizations": [
+			{
+			"bcc": [
+				{
+				"email": "sam.doe@example.com",
+				"name": "Sam Doe"
+				}
+			],
+			"cc": [
+				{
+				"email": "jane.doe@example.com",
+				"name": "Jane Doe"
+				}
+			],
+			"custom_args": {
+				"New Argument 1": "New Value 1",
+				"activationAttempt": "1",
+				"customerAccountNumber": "[CUSTOMER ACCOUNT NUMBER GOES HERE]"
+			},
+			"headers": {
+				"X-Accept-Language": "en",
+				"X-Mailer": "MyApp"
+			},
+			"send_at": 1409348513,
+			"subject": "Hello, World!",
+			"substitutions": {
+				"id": "substitutions",
+				"type": "object"
+			},
+			"to": [
+				{
+				"email": "john.doe@example.com",
+				"name": "John Doe"
+				}
+			]
+			}
+		],
+		"reply_to": {
+			"email": "sam.smith@example.com",
+			"name": "Sam Smith"
+		},
+		"sections": {
+			"section": {
+			":sectionName1": "section 1 text",
+			":sectionName2": "section 2 text"
+			}
+		},
+		"send_at": 1409348513,
+		"subject": "Hello, World!",
+		"template_id": "[YOUR TEMPLATE ID GOES HERE]",
+		"tracking_settings": {
+			"click_tracking": {
+			"enable": true,
+			"enable_text": true
+			},
+			"ganalytics": {
+			"enable": true,
+			"utm_campaign": "[NAME OF YOUR REFERRER SOURCE]",
+			"utm_content": "[USE THIS SPACE TO DIFFERENTIATE YOUR EMAIL FROM ADS]",
+			"utm_medium": "[NAME OF YOUR MARKETING MEDIUM e.g. email]",
+			"utm_name": "[NAME OF YOUR CAMPAIGN]",
+			"utm_term": "[IDENTIFY PAID KEYWORDS HERE]"
+			},
+			"open_tracking": {
+			"enable": true,
+			"substitution_tag": "%opentrack"
+			},
+			"subscription_tracking": {
+			"enable": true,
+			"html": "If you would like to unsubscribe and stop receiving these emails <% clickhere %>.",
+			"substitution_tag": "<%click here%>",
+			"text": "If you would like to unsubscribe and stop receiveing these emails <% click here %>."
+			}
+		}
+		}`)
+	client.Request.Headers["X-Mock"] = "202"
+	response, err := API(client.Request)
+	if err != nil {
+		fmt.Println(err)
+	}
+	if response.StatusCode != 202 {
+		t.Error("Wrong status code returned")
+	}
+}
+
 func Test_test_mail_send_post(t *testing.T) {
 	apiKey := "SENDGRID_APIKEY"
 	host := "http://localhost:4010"


### PR DESCRIPTION
Fixes #87 
Add new client helper that encapsulates sending an mail
Add a send func for the client that takes an email and triggers the email request

**Sample usage**

``` go
package main

import (
    "fmt"
    "github.com/sendgrid/sendgrid-go"
    "github.com/sendgrid/sendgrid-go/helpers/mail"
    "os"
)

func main() {
    client := sendgrid.NewSendClient(os.Getenv("SENDGRID_API_KEY"))
    from := mail.NewEmail("Example User", "test@example.com")
    subject := "Hello World from the SendGrid Go Library"
    to := mail.NewEmail("Example User", "test@example.com")
    plainTextContent := "some text here"
    htmlContent := "<strong>some HTML content</strong>"
    email := mail.NewSingleEmail(from, subject, to, plainTextContent, htmlContent)

    response, err := client.Send(email)
    if err != nil {
        log.Println(err)
    } else {
        fmt.Println(response.StatusCode)
        fmt.Println(response.Body)
        fmt.Println(response.Headers)
    }
}
```
