### PR TITLE
Fixed code to allow prism.exe to run properly in windows

### DIFF
--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -33,6 +34,7 @@ func TestMain(m *testing.M) {
 	testHost = "http://localhost:4010"
 
 	if runtime.GOOS == "windows" {
+		prismPath = filepath.Join(os.Getenv("GOPATH"), "bin", prismPath)
 		prismPath += ".exe"
 	}
 


### PR DESCRIPTION
@thinkingserious I ran _go test_ (on my windows machine) and it asked me to download prism.exe & place it in _GOPATH/bin_. I did that but it would not work, until I fix the code. 
