### PR TITLE
Fixing mimetypes in the NewSingleEmail function

### DIFF
--- a/helpers/mail/mail_v3.go
+++ b/helpers/mail/mail_v3.go
@@ -512,8 +512,8 @@ func NewEmail(name string, address string) *Email {
 }
 
 func NewSingleEmail(from *Email, subject string, to *Email, plainTextContent string, htmlContent string) *SGMailV3 {
-	plainText := NewContent("text", plainTextContent)
-	html := NewContent("html", htmlContent)
+	plainText := NewContent("text/plain", plainTextContent)
+	html := NewContent("text/html", htmlContent)
 	return NewV3MailInit(from, subject, to, plainText, html)
 }
 


### PR DESCRIPTION
As of today the `NewSingleEmail` function doesn't use the right mimetypes which cause mail clients to interprete only the plaintext part of the sent mails. This PR fixes this.