### PR TITLE
Added a warning about the error return from sendgrid.API

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -35,6 +35,7 @@ Click the "Clone or download" green button in [GitHub](https://github.com/sendgr
 ## Error Messages
 
 An error is returned if caused by client policy (such as CheckRedirect), or failure to speak HTTP (such as a network connectivity problem).
+
 To read the error message returned by SendGrid's API:
 
 ```go
@@ -58,6 +59,7 @@ func main() {
 	}
 }
 ```
+
 __CAUTION__: A non-2xx status code doesn't cause an error on sendgrid.API and the application has to verify the response:
 
 ```golang
@@ -66,10 +68,10 @@ if err != nil {
 	return err
 }
 if resp.StatusCode >= 400 {
-	// something goes wrong and you have to handle (returning an error to the user or logging the problem)
+	// something goes wrong and you have to handle (e.g. returning an error to the user or logging the problem)
 	log.Printf("api response: HTTP %d: %s", resp.StatusCode, resp.Body)
 	// OR
-	return fmt.Errorf("api response: HTTP %d: %s", resp.StatusCode, resp.Body)
+	// return fmt.Errorf("api response: HTTP %d: %s", resp.StatusCode, resp.Body)
 }
 ```
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -34,6 +34,7 @@ Click the "Clone or download" green button in [GitHub](https://github.com/sendgr
 <a name="error"></a>
 ## Error Messages
 
+An error is returned if caused by client policy (such as CheckRedirect), or failure to speak HTTP (such as a network connectivity problem).
 To read the error message returned by SendGrid's API:
 
 ```go
@@ -55,6 +56,17 @@ func main() {
 		fmt.Println(response.Body)
 		fmt.Println(response.Headers)
 	}
+}
+```
+__CAUTION__: A non-2xx status code doesn't cause an error on sendgrid.API and the application have to verify the response:
+
+```golang
+resp, err := sendgrid.API(request)
+if err != nil {
+	return err
+}
+if resp.StatusCode >= 400 {
+	return fmt.Errorf("api response: HTTP %d: %s", resp.StatusCode, resp.Body)
 }
 ```
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -58,7 +58,7 @@ func main() {
 	}
 }
 ```
-__CAUTION__: A non-2xx status code doesn't cause an error on sendgrid.API and the application have to verify the response:
+__CAUTION__: A non-2xx status code doesn't cause an error on sendgrid.API and the application has to verify the response:
 
 ```golang
 resp, err := sendgrid.API(request)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -66,6 +66,9 @@ if err != nil {
 	return err
 }
 if resp.StatusCode >= 400 {
+	// something goes wrong and you have to handle (returning an error to the user or logging the problem)
+	log.Printf("api response: HTTP %d: %s", resp.StatusCode, resp.Body)
+	// OR
 	return fmt.Errorf("api response: HTTP %d: %s", resp.StatusCode, resp.Body)
 }
 ```


### PR DESCRIPTION
The solution for the issue #99 was this warning because the sendgrid.API is a generic function and should not handle this problem.
closes #99