### PR TITLE
issues#125 Auto-generate Plaintext

### DIFF
--- a/examples/helpers/mail/example.go
+++ b/examples/helpers/mail/example.go
@@ -5,7 +5,7 @@ package main
 import (
 	"fmt"
 
-	sendgrid "github.com/hacktoberfest/sendgrid-go"
+	"github.com/sendgrid/sendgrid-go"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 	//"../../.." // to test against the downloaded version
 	//"../../../../sendgrid-go/helpers/mail" // to test against the downloaded version
@@ -193,7 +193,6 @@ func kitchenSink() []byte {
 	return mail.GetRequestBody(m)
 }
 
-// Minimum required to send an email
 func helloEmailAutogeneratePlaintext() []byte {
 	address := "test@example.com"
 	name := "Example User"

--- a/examples/helpers/mail/example.go
+++ b/examples/helpers/mail/example.go
@@ -1,9 +1,11 @@
 package main
+
 // This is an example of the Mail helper, located here: /helpers/mail
 
 import (
 	"fmt"
-	"github.com/sendgrid/sendgrid-go"
+
+	sendgrid "github.com/hacktoberfest/sendgrid-go"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 	//"../../.." // to test against the downloaded version
 	//"../../../../sendgrid-go/helpers/mail" // to test against the downloaded version
@@ -134,7 +136,7 @@ func kitchenSink() []byte {
 	asm.AddGroupsToDisplay(99)
 	m.SetASM(asm)
 
-  // This must be a valid [batch ID](https://sendgrid.com/docs/API_Reference/SMTP_API/scheduling_parameters.html) to work
+	// This must be a valid [batch ID](https://sendgrid.com/docs/API_Reference/SMTP_API/scheduling_parameters.html) to work
 	// m.SetBatchID("sendgrid_batch_id")
 
 	m.SetIPPoolID("23")
@@ -191,10 +193,50 @@ func kitchenSink() []byte {
 	return mail.GetRequestBody(m)
 }
 
+// Minimum required to send an email
+func helloEmailAutogeneratePlaintext() []byte {
+	address := "test@example.com"
+	name := "Example User"
+	from := mail.NewEmail(name, address)
+	subject := "Hello World from the SendGrid Go Library"
+	address = "test@example.com"
+	name = "Example User"
+	to := mail.NewEmail(name, address)
+
+	html := mail.NewContent("text/html", "<html><body><h1>Some HTML text here</h1><body></html>")
+
+	plaintext, err := mail.NewPlaintextContentFromHTML(html.Value)
+	if err != nil {
+		panic(err)
+	}
+
+	m := mail.NewV3MailInit(from, subject, to, html, plaintext)
+	address = "test2@example.com"
+	name = "Example User"
+	email := mail.NewEmail(name, address)
+	m.Personalizations[0].AddTos(email)
+	return mail.GetRequestBody(m)
+}
+
 func sendHelloEmail() {
 	request := sendgrid.GetRequest(os.Getenv("YOUR_SENDGRID_API_KEY"), "/v3/mail/send", "https://api.sendgrid.com")
 	request.Method = "POST"
 	var Body = helloEmail()
+	request.Body = Body
+	response, err := sendgrid.API(request)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(response.StatusCode)
+		fmt.Println(response.Body)
+		fmt.Println(response.Headers)
+	}
+}
+
+func sendHelloEmailAutogeneratePlaintext() {
+	request := sendgrid.GetRequest(os.Getenv("YOUR_SENDGRID_API_KEY"), "/v3/mail/send", "https://api.sendgrid.com")
+	request.Method = "POST"
+	var Body = helloEmailAutogeneratePlaintext()
 	request.Body = Body
 	response, err := sendgrid.API(request)
 	if err != nil {
@@ -223,5 +265,6 @@ func sendKitchenSink() {
 
 func main() {
 	sendHelloEmail()
+	sendHelloEmailAutogeneratePlaintext()
 	sendKitchenSink()
 }

--- a/examples/helpers/mail/example.go
+++ b/examples/helpers/mail/example.go
@@ -209,7 +209,8 @@ func helloEmailAutogeneratePlaintext() []byte {
 		panic(err)
 	}
 
-	m := mail.NewV3MailInit(from, subject, to, html, plaintext)
+	// if text/plain and text/html are set, text/plain should be first
+	m := mail.NewV3MailInit(from, subject, to, plaintext, html)
 	address = "test2@example.com"
 	name = "Example User"
 	email := mail.NewEmail(name, address)

--- a/helpers/mail/README.md
+++ b/helpers/mail/README.md
@@ -3,6 +3,7 @@
 ## Dependencies
 
 - [rest](https://github.com/sendgrid/rest)
+- [textplain](https://github.com/mailproto/textplain)
 
 # Quick Start
 

--- a/helpers/mail/mail_v3.go
+++ b/helpers/mail/mail_v3.go
@@ -3,6 +3,8 @@ package mail
 import (
 	"encoding/json"
 	"log"
+
+	"github.com/mailproto/textplain"
 )
 
 type SGMailV3 struct {
@@ -522,6 +524,18 @@ func NewContent(contentType string, value string) *Content {
 		Type:  contentType,
 		Value: value,
 	}
+}
+
+func NewPlaintextContentFromHTML(html string) (*Content, error) {
+	converted, err := textplain.Convert(html, -1)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Content{
+		Type:  "text/plain",
+		Value: converted,
+	}, nil
 }
 
 func NewClickTrackingSetting() *ClickTrackingSetting {

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -963,3 +963,45 @@ func TestV3NewSandboxModeSetting(t *testing.T) {
 		t.Error("SpamCheck should not be nil")
 	}
 }
+
+func TestV3GeneratePlaintext(t *testing.T) {
+	from := NewEmail("Example User", "test@example.com")
+	subject := "Hello World from the SendGrid Go Library"
+	to := NewEmail("Example User", "test@example.com")
+	content := NewContent("text/html", "<html><body><h1>Hello World From Sendgrid</h1><p>Thanks for auto-generating this</p></body></html>")
+	m := NewV3MailInit(from, subject, to, content)
+
+	if m == nil {
+		t.Errorf("NewV3MailInit() shouldn't return nil")
+	}
+
+	if m.Content == nil {
+		t.Fatalf("Content should not be nil")
+	}
+
+	plaintext, err := NewPlaintextContentFromHTML(m.Content[0].Value)
+	if err != nil {
+		t.Error("NewPlaintextContentFromHTML should not return nil")
+	}
+
+	m.AddContent(plaintext)
+
+	if len(m.Content) != 2 {
+		t.Fatalf("Content should have 2 entries, found %d", 1)
+	}
+
+	if m.Content[1].Type != "text/plain" {
+		t.Errorf("Expected additional type to be text/plain, got: %v", m.Content[1].Type)
+	}
+
+	expectPlaintext := `*************************
+Hello World From Sendgrid
+*************************
+
+Thanks for auto-generating this`
+
+	if plain := m.Content[1].Value; plain != expectPlaintext {
+		t.Errorf("Wrong plaintext value, want:\n%v, got:\n%v", expectPlaintext, plain)
+	}
+
+}

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -986,11 +986,11 @@ func TestV3GeneratePlaintext(t *testing.T) {
 	}
 
 	if len(m.Content) != 2 {
-		t.Fatalf("Content should have 2 entries, found %d", 1)
+		t.Fatalf("Content should have 2 entries, found %d", len(m.Content))
 	}
 
 	if m.Content[0].Type != "text/plain" {
-		t.Errorf("Expected additional type to be text/plain, got: %v", m.Content[1].Type)
+		t.Errorf("Expected first type to be text/plain, got: %v", m.Content[1].Type)
 	}
 
 	expectPlaintext := `*************************

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -968,8 +968,14 @@ func TestV3GeneratePlaintext(t *testing.T) {
 	from := NewEmail("Example User", "test@example.com")
 	subject := "Hello World from the SendGrid Go Library"
 	to := NewEmail("Example User", "test@example.com")
-	content := NewContent("text/html", "<html><body><h1>Hello World From Sendgrid</h1><p>Thanks for auto-generating this</p></body></html>")
-	m := NewV3MailInit(from, subject, to, content)
+	html := NewContent("text/html", "<html><body><h1>Hello World From Sendgrid</h1><p>Thanks for auto-generating this</p></body></html>")
+
+	plaintext, err := NewPlaintextContentFromHTML(html.Value)
+	if err != nil {
+		t.Error("NewPlaintextContentFromHTML should not return nil")
+	}
+
+	m := NewV3MailInit(from, subject, to, plaintext, html)
 
 	if m == nil {
 		t.Errorf("NewV3MailInit() shouldn't return nil")
@@ -979,18 +985,11 @@ func TestV3GeneratePlaintext(t *testing.T) {
 		t.Fatalf("Content should not be nil")
 	}
 
-	plaintext, err := NewPlaintextContentFromHTML(m.Content[0].Value)
-	if err != nil {
-		t.Error("NewPlaintextContentFromHTML should not return nil")
-	}
-
-	m.AddContent(plaintext)
-
 	if len(m.Content) != 2 {
 		t.Fatalf("Content should have 2 entries, found %d", 1)
 	}
 
-	if m.Content[1].Type != "text/plain" {
+	if m.Content[0].Type != "text/plain" {
 		t.Errorf("Expected additional type to be text/plain, got: %v", m.Content[1].Type)
 	}
 
@@ -1000,7 +999,7 @@ Hello World From Sendgrid
 
 Thanks for auto-generating this`
 
-	if plain := m.Content[1].Value; plain != expectPlaintext {
+	if plain := m.Content[0].Value; plain != expectPlaintext {
 		t.Errorf("Wrong plaintext value, want:\n%v, got:\n%v", expectPlaintext, plain)
 	}
 

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -972,7 +972,7 @@ func TestV3GeneratePlaintext(t *testing.T) {
 
 	plaintext, err := NewPlaintextContentFromHTML(html.Value)
 	if err != nil {
-		t.Error("NewPlaintextContentFromHTML should not return nil")
+		t.Errorf("NewPlaintextContentFromHTML should not return an error, got: %v", err)
 	}
 
 	m := NewV3MailInit(from, subject, to, plaintext, html)


### PR DESCRIPTION
Adds a new function: `NewPlaintextContentFromHTML`, that leverages the plaintext-generation capabilities from https://github.com/mailproto/textplain to convert HTML content into formatted plaintext. 

**Usage:**

```go
// ...
html := mail.NewContent("text/html", "<html><body><h1>Hello World</h1><p>Body text</p></body></html>")
plaintext, err := mail.NewPlaintextContentFromHTML(html.Value)
// check error here
m := mail.NewV3MailInit(from, subject, to, plaintext, html)
```

Which will generate a plaintext body that looks like: 
```
***********
Hello World
***********

Body text
```

mailproto/textplain uses an adapted version of the [plaintext formatting rules](https://github.com/premailer/premailer/blob/master/lib/premailer/html_to_plain_text.rb) found in https://github.com/premailer/premailer, and has support for custom formatting for **img**, **a**, **h[1-6]**, **span**, **li**, **p** and **br**, skips **head** content and cleans out html comments

If it would be preferable not to add an external dependency, I 'd be happy to update this PR to instead embed textplain as a helper file in the sendgrid-go library itself

Fixes #125