### PR TITLE
Go vet fixes related to #162

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 temp.go
+*.swp

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -63,7 +63,7 @@ func TestV3AddPersonalizations(t *testing.T) {
 	m.AddPersonalizations(personalizations...)
 
 	if len(m.Personalizations) != numOfPersonalizations {
-		t.Errorf("Mail should have %d personalizations, got %d personalizations", personalizations, len(m.Personalizations))
+		t.Errorf("Mail should have %d personalizations, got %d personalizations", len(personalizations), len(m.Personalizations))
 	}
 }
 
@@ -78,7 +78,7 @@ func TestV3AddContent(t *testing.T) {
 	m.AddContent(content...)
 
 	if len(m.Content) != numOfContent {
-		t.Errorf("Mail should have %d contents, got %d contents", content, len(m.Content))
+		t.Errorf("Mail should have %d contents, got %d contents", len(content), len(m.Content))
 	}
 }
 
@@ -93,7 +93,7 @@ func TestV3AddAttachment(t *testing.T) {
 	m.AddAttachment(attachment...)
 
 	if len(m.Attachments) != numOfAttachments {
-		t.Errorf("Mail should have %d attachments, got %d attachments", attachment, 2)
+		t.Errorf("Mail should have %d attachments, got %d attachments", len(attachment), len(m.Attachments))
 	}
 }
 
@@ -226,7 +226,7 @@ func TestV3SetIPPoolID(t *testing.T) {
 
 	m.SetIPPoolID(ipPoolID)
 	if m.IPPoolID != ipPoolID {
-		t.Errorf("IP Pool ID should be %d, got %d", ipPoolID, m.IPPoolID)
+		t.Errorf("IP Pool ID should be %s, got %s", ipPoolID, m.IPPoolID)
 	}
 }
 


### PR DESCRIPTION
With this PR, go vet no longer finds any issues in this repository.

Also included a commit to update `.gitignore` to ignore `.swp` file generated by vim.