### PR TITLE
Fix wrong mail helpers example directory in README

### DIFF
--- a/helpers/mail/README.md
+++ b/helpers/mail/README.md
@@ -9,7 +9,7 @@
 Run the [example](https://github.com/sendgrid/sendgrid-go/tree/master/examples/mail) (make sure you have set your environment variable to include your SENDGRID_API_KEY).
 
 ```bash
-go run examples/mail/example.go
+go run examples/helpers/mail/example.go
 ```
 
 ## Usage

--- a/helpers/mail/README.md
+++ b/helpers/mail/README.md
@@ -6,7 +6,7 @@
 
 # Quick Start
 
-Run the [example](https://github.com/sendgrid/sendgrid-go/tree/master/examples/mail) (make sure you have set your environment variable to include your SENDGRID_API_KEY).
+Run the [example](https://github.com/sendgrid/sendgrid-go/tree/master/examples/helpers/mail/example.go) (make sure you have set your environment variable to include your SENDGRID_API_KEY).
 
 ```bash
 go run examples/helpers/mail/example.go
@@ -14,7 +14,7 @@ go run examples/helpers/mail/example.go
 
 ## Usage
 
-- See the [example](https://github.com/sendgrid/sendgrid-go/tree/master/examples/mail) for a complete working example.
+- See the [example](https://github.com/sendgrid/sendgrid-go/tree/master/examples/helpers/mail/example.go) for a complete working example.
 - [Documentation](https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/overview.html)
 
 ## Test


### PR DESCRIPTION
### What

The example directory for mail helpers is incorrect in **helpers/mail/README.md**. This fixes that.

### Why

It might confuse the user with **examples/mail/mail.go**