### PR TITLE
Megacheck found 2 small issues

### DIFF
--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -161,7 +161,7 @@ func TestCustomHTTPClient(t *testing.T) {
 	if err == nil {
 		t.Error("A timeout did not trigger as expected")
 	}
-	if strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") == false {
+	if !strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") {
 		t.Error("We did not receive the Timeout error")
 	}
 }

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -20,14 +20,13 @@ import (
 )
 
 var (
-	testAPIKey = "SENDGRID_APIKEY"
-	testHost   = ""
-	prismPath  = "prism"
-	prismArgs  = []string{"run", "-s", "https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/oai_stoplight.json"}
-	prismCmd   *exec.Cmd
-	buffer     bytes.Buffer
-	curl       *exec.Cmd
-	sh         *exec.Cmd
+	testHost  = ""
+	prismPath = "prism"
+	prismArgs = []string{"run", "-s", "https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/oai_stoplight.json"}
+	prismCmd  *exec.Cmd
+	buffer    bytes.Buffer
+	curl      *exec.Cmd
+	sh        *exec.Cmd
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
[honnef.co/go/tools/cmd/megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) found 2 small issues:

```
sendgrid_test.go:23:2: var testAPIKey is unused (U1000)
sendgrid_test.go:165:5: should omit comparison to bool constant, can be simplified to !strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") (S1002)
```

This PR removes the unused variable and simplifies the boolean condition.