### PR TITLE
Fix spelling and formatting of comments in mail_v3.go

### DIFF
--- a/helpers/mail/mail_v3.go
+++ b/helpers/mail/mail_v3.go
@@ -5,7 +5,7 @@ import (
 	"log"
 )
 
-// SGMailV3  contains mail struct
+// SGMailV3 contains mail struct
 type SGMailV3 struct {
 	From             *Email             `json:"from,omitempty"`
 	Subject          string             `json:"subject,omitempty"`
@@ -39,19 +39,19 @@ type Personalization struct {
 	SendAt        int               `json:"send_at,omitempty"`
 }
 
-// Email holds email Name and adress info
+// Email holds email name and address info
 type Email struct {
 	Name    string `json:"name,omitempty"`
 	Address string `json:"email,omitempty"`
 }
 
-// Content defines  content of the mail body
+// Content defines content of the mail body
 type Content struct {
 	Type  string `json:"type,omitempty"`
 	Value string `json:"value,omitempty"`
 }
 
-// Attachment  holds attachement information
+// Attachment holds attachement information
 type Attachment struct {
 	Content     string `json:"content,omitempty"`
 	Type        string `json:"type,omitempty"`


### PR DESCRIPTION
# Fixes # 

Fixes #190 

- Fixes spelling issues found by [Go Report Card](https://goreportcard.com/report/github.com/sendgrid/sendgrid-go)