### PR TITLE
docs: Update examples using inline attachment with ContentID

### DIFF
--- a/examples/helpers/mail/example.go
+++ b/examples/helpers/mail/example.go
@@ -103,7 +103,6 @@ func kitchenSink() []byte {
 	a.SetType("application/pdf")
 	a.SetFilename("balance_001.pdf")
 	a.SetDisposition("attachment")
-	a.SetContentID("Balance Sheet")
 	m.AddAttachment(a)
 
 	a2 := mail.NewAttachment()
@@ -111,6 +110,7 @@ func kitchenSink() []byte {
 	a2.SetType("image/png")
 	a2.SetFilename("banner.png")
 	a2.SetDisposition("inline")
+	// Content-ID header is included when the attachment disposition is set to "inline"
 	a2.SetContentID("Banner")
 	m.AddAttachment(a2)
 

--- a/use-cases/attachments-with-mailer-helper.md
+++ b/use-cases/attachments-with-mailer-helper.md
@@ -43,7 +43,6 @@ func main() {
   a_txt.SetType("text/plain")
   a_txt.SetFilename("testing.txt")
   a_txt.SetDisposition("attachment")
-  a_txt.SetContentID("Test Document")
   
   // read/attach .pdf file
   a_pdf := mail.NewAttachment()
@@ -56,9 +55,8 @@ func main() {
   a_pdf.SetType("application/pdf")
   a_pdf.SetFilename("testing.pdf")
   a_pdf.SetDisposition("attachment")
-  a_pdf.SetContentID("Test Attachment")
 
-  // read/attach .jpg file
+  // read/attach inline .jpg file
   a_jpg := mail.NewAttachment()
   dat, err = ioutil.ReadFile("testing.jpg")
   if err != nil {
@@ -68,7 +66,7 @@ func main() {
   a_jpg.SetContent(encoded)
   a_jpg.SetType("image/jpeg")
   a_jpg.SetFilename("testing.jpg")
-  a_jpg.SetDisposition("attachment")
+  a_jpg.SetDisposition("inline")
   a_jpg.SetContentID("Test Attachment")
   
   // add `a_txt`, `a_pdf` and `a_jpg` to `m`

--- a/use-cases/attachments-without-mailer-helper.md
+++ b/use-cases/attachments-without-mailer-helper.md
@@ -38,21 +38,19 @@ func main() {
      "attachments": [
         {
           "content": "SGVsbG8gV29ybGQh", 
-          "content_id": "testing_1", 
           "disposition": "attachment", 
           "filename": "testing.txt", 
           "type": "txt"
         },
         {
           "content": "BASE64 encoded content block here", 
+          "disposition": "inline", 
           "content_id": "testing_2", 
-          "disposition": "attachment", 
           "filename": "testing.jpg", 
           "type": "jpg"
         },
         {
-          "content": "BASE64 encoded content block here", 
-          "content_id": "testing_3", 
+          "content": "BASE64 encoded content block here",
           "disposition": "attachment", 
           "filename": "testing.pdf", 
           "type": "pdf"


### PR DESCRIPTION
# Fixes #251

### Checklist
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guide] and my PR follows them.
- [X] I updated my branch with the master branch.
- [X] I have added necessary documentation about the functionality in the appropriate .md file
- [X] I have added in line documentation to the code I modified

### Short description of what this PR does:
This is a minor adjustment to attachment usage with `SetContentID`, hopefully making its use a bit clearer. The "Content-ID" header in a mail message is commonly used to reference the "Content-Disposition: inline;" embedded data within the HTML body. In many implementations the "Content-ID" header is omitted when the disposition is set to "attachment".

###  References
https://tools.ietf.org/html/rfc2183

