### PR TITLE
Directly link to the online version of the CLA in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ Quick links:
 
 - [Feature Request](https://github.com/sendgrid/sendgrid-go/tree/master/CONTRIBUTING.md#feature-request)
 - [Bug Reports](https://github.com/sendgrid/sendgrid-go/tree/master/CONTRIBUTING.md#submit-a-bug-report)
-- [Sign the CLA to Create a Pull Request](https://github.com/sendgrid/sendgrid-go/tree/master/CONTRIBUTING.md#cla)
 - [Improvements to the Codebase](https://github.com/sendgrid/sendgrid-go/tree/master/CONTRIBUTING.md#improvements-to-the-codebase)
+- Sign the CLA to Create a Pull Request [here](https://cla.sendgrid.com/sendgrid/sendgrid-go)
 
 <a name="troubleshooting"></a>
 # Troubleshooting
@@ -251,7 +251,9 @@ Please see our [troubleshooting guide](https://github.com/sendgrid/sendgrid-go/b
 <a name="about"></a>
 # About
 
-sendgrid-go is guided and supported by the SendGrid [Developer Experience Team](mailto:dx@sendgrid.com).
+sendgrid-go is guided and supported by the SendGrid Developer Experience Team.
+
+Email the Developer Experience Team [here](mailto:dx@sendgrid.com) in case of any queries or assistance.
 
 sendgrid-go is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-go are trademarks of SendGrid, Inc.
 


### PR DESCRIPTION
Directly link to the online version of the CLA in the README.md file and fix the email mentions, as done in earlier repositories of sendgrid-python and sendgrid-java

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
## Fixes #302 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Directly links to the online version of the CLA in README.md
- Fixes the issue of mentioning email similar to sendgrid-python and sendgrid-java
