### PR TITLE
make imports more explicit in USE_CASES.md

### DIFF
--- a/use-cases/attachments-with-mailer-helper.md
+++ b/use-cases/attachments-with-mailer-helper.md
@@ -9,7 +9,7 @@ import (
   "os"
   "encoding/base64"
   "io/ioutil"
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 

--- a/use-cases/attachments-without-mailer-helper.md
+++ b/use-cases/attachments-without-mailer-helper.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
  
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
  
 func main() {

--- a/use-cases/custom-args-with-mailer-helper.md
+++ b/use-cases/custom-args-with-mailer-helper.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 

--- a/use-cases/custom-args-without-mailer-helper.md
+++ b/use-cases/custom-args-without-mailer-helper.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {

--- a/use-cases/legacy-templates-with-mailer-helper.md
+++ b/use-cases/legacy-templates-with-mailer-helper.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 

--- a/use-cases/legacy-templates-without-mailer-helper.md
+++ b/use-cases/legacy-templates-without-mailer-helper.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {

--- a/use-cases/personalization-sending-single-email-single-recipient-with-cc-bcc.md
+++ b/use-cases/personalization-sending-single-email-single-recipient-with-cc-bcc.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 

--- a/use-cases/personalization-sending-single-email-single-recipient-with-cc.md
+++ b/use-cases/personalization-sending-single-email-single-recipient-with-cc.md
@@ -9,7 +9,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 

--- a/use-cases/personalization-sending-single-email-single-recipient.md
+++ b/use-cases/personalization-sending-single-email-single-recipient.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 

--- a/use-cases/personalization-sending-single-email-to-multiple-recipients.md
+++ b/use-cases/personalization-sending-single-email-to-multiple-recipients.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 

--- a/use-cases/personalization-sending-single-email-to-single-recipients-with-multiple-cc-bcc.md
+++ b/use-cases/personalization-sending-single-email-to-single-recipients-with-multiple-cc-bcc.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 

--- a/use-cases/personalization-sending-two-emails-to-two-groups-recipients.md
+++ b/use-cases/personalization-sending-two-emails-to-two-groups-recipients.md
@@ -9,7 +9,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 

--- a/use-cases/personalization-without-helper-sending-same-email-to-multiple-recipients.md
+++ b/use-cases/personalization-without-helper-sending-same-email-to-multiple-recipients.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {

--- a/use-cases/personalization-without-helper-sending-single-email-single-recipient-with-cc-bcc.md
+++ b/use-cases/personalization-without-helper-sending-single-email-single-recipient-with-cc-bcc.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {

--- a/use-cases/personalization-without-helper-sending-single-email-single-recipient-with-cc.md
+++ b/use-cases/personalization-without-helper-sending-single-email-single-recipient-with-cc.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {

--- a/use-cases/personalization-without-helper-sending-single-email-single-recipient.md
+++ b/use-cases/personalization-without-helper-sending-single-email-single-recipient.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {

--- a/use-cases/personalization-without-helper-sending-single-email-to-single-recipients-with-multiple-cc-bcc.md
+++ b/use-cases/personalization-without-helper-sending-single-email-to-single-recipients-with-multiple-cc-bcc.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {

--- a/use-cases/personalization-without-helper-sending-two-emails-to-two-groups-recipients.md
+++ b/use-cases/personalization-without-helper-sending-two-emails-to-two-groups-recipients.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
 
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {

--- a/use-cases/sections-with-mailer-helper.md
+++ b/use-cases/sections-with-mailer-helper.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
  
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
  

--- a/use-cases/sections-without-mailer-helper.md
+++ b/use-cases/sections-without-mailer-helper.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
  
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
  
 func main() {

--- a/use-cases/setup-domain-whitelabel.md
+++ b/use-cases/setup-domain-whitelabel.md
@@ -12,7 +12,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/sendgrid/sendgrid-go"
+	sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {

--- a/use-cases/substitutions-with-mailer-helper.md
+++ b/use-cases/substitutions-with-mailer-helper.md
@@ -8,7 +8,7 @@ import (
    "log"
    "os"
  
-   "github.com/sendgrid/sendgrid-go"
+   sendgrid "github.com/sendgrid/sendgrid-go"
    "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
  

--- a/use-cases/substitutions-without-mailer-helper.md
+++ b/use-cases/substitutions-without-mailer-helper.md
@@ -8,7 +8,7 @@ import (
   "log"
   "os"
  
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
 )
  
 func main() {

--- a/use-cases/transactional-templates-with-mailer-helper.md
+++ b/use-cases/transactional-templates-with-mailer-helper.md
@@ -5,7 +5,7 @@ package main
 
 import (
   "fmt"
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
   "os"
 )

--- a/use-cases/transactional-templates-without-mailer-helper.md
+++ b/use-cases/transactional-templates-without-mailer-helper.md
@@ -5,7 +5,7 @@ package main
 
 import (
   "fmt"
-  "github.com/sendgrid/sendgrid-go"
+  sendgrid "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
   "os"
 )

--- a/use-cases/view-email-stats.md
+++ b/use-cases/view-email-stats.md
@@ -10,7 +10,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/sendgrid/sendgrid-go"
+	sendgrid "github.com/sendgrid/sendgrid-go"
 )
 
 func main() {


### PR DESCRIPTION
### Fixes
Resolves #112 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
The prevents confusion when readers uses tools that incorrectly report symbols like `sendgrid.GetRequest`  as undefined when they see `import "github.com/sendgrid/sendgrid-go"`