### PR TITLE
Fix capitalization error in X-Ratelimit-Reset header name.

### DIFF
--- a/sendgrid.go
+++ b/sendgrid.go
@@ -131,7 +131,7 @@ func MakeRequestRetry(request rest.Request) (*rest.Response, error) {
 
 		resetTime := time.Now().Add(rateLimitSleep * time.Millisecond)
 
-		reset, ok := response.Headers["X-RateLimit-Reset"]
+		reset, ok := response.Headers["X-Ratelimit-Reset"]
 		if ok && len(reset) > 0 {
 			t, err := strconv.Atoi(reset[0])
 			if err == nil {


### PR DESCRIPTION
`MakeRequestRetry()` looks for the wrong header. `X-RateLimit-Reset` instead of the `X-Ratelimit-Reset` header actually sent by the API. This causes it to retry without waiting for the reset time until it ultimately fails.