### PR TITLE
Double quote escape names with special characters

### DIFF
--- a/helpers/mail/mail_v3.go
+++ b/helpers/mail/mail_v3.go
@@ -605,6 +605,9 @@ func NewSetting(enable bool) *Setting {
 
 // NewEmail ...
 func NewEmail(name string, address string) *Email {
+	if len(name) < 2 || name[0] != '"' || name[len(name)-1] != '"' {
+		name = "\"" + name + "\""
+	}
 	return &Email{
 		Name:    name,
 		Address: address,

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -72,6 +72,34 @@ func TestV3AddAttachment(t *testing.T) {
 	assert.Equal(t, numOfAttachments, len(m.Attachments), fmt.Sprintf("Mail should have %d attachments, got %d attachments", numOfAttachments, len(m.Attachments)))
 }
 
+func TestEscapeName(t *testing.T) {
+	testcases := []struct {
+		title string
+		name  string
+		want  string
+	}{
+		{"contains double quote", `Johnny"Bravo`, `"Johnny\"Bravo"`},
+		{"contains backslash", `Johnny\Bravo`, `"Johnny\\Bravo"`},
+		{"contains open parens", `Johnny (Bravo`, `"Johnny (Bravo"`},
+		{"contains close parens", `Johnny Bravo)`, `"Johnny Bravo)"`},
+		{"contains open angle bracket", `Johnny <Bravo`, `"Johnny <Bravo"`},
+		{"contains open angle bracket", `Johnny Bravo>`, `"Johnny Bravo>"`},
+		{"contains open square bracket", `Johnny [Bravo`, `"Johnny [Bravo"`},
+		{"contains open square bracket", `Johnny Bravo]`, `"Johnny Bravo]"`},
+		{"contains colon", `Johnny:Bravo`, `"Johnny:Bravo"`},
+		{"contains semi-colon", `Johnny;Bravo`, `"Johnny;Bravo"`},
+		{"contains at sign", `Johnny@Bravo`, `"Johnny@Bravo"`},
+		{"contains comma", `Johnny,Bravo`, `"Johnny,Bravo"`},
+		{"contains period", `Johnny.Bravo`, `"Johnny.Bravo"`},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EscapeName(tc.name)
+			assert.Equal(t, tc.want, got, fmt.Sprintf("name should be %s, got %s", tc.want, got))
+		})
+	}
+}
+
 func TestV3SetFrom(t *testing.T) {
 	m := NewV3Mail()
 
@@ -80,8 +108,8 @@ func TestV3SetFrom(t *testing.T) {
 		name  string
 		want  string
 	}{
-		{"unquoted", "Test User", "\"Test User\""},
-		{"double quoted", "\"Test User\"", "\"Test User\""},
+		{"unquoted", `Test User`, `Test User`},
+		{"quoted", `"Test User"`, `"Test User"`},
 	}
 
 	address := "test@example.com"
@@ -102,8 +130,8 @@ func TestV3SetReplyTo(t *testing.T) {
 		name  string
 		want  string
 	}{
-		{"unquoted", "Test User", "\"Test User\""},
-		{"double quoted", "\"Test User\"", "\"Test User\""},
+		{"unquoted", `Test User`, `Test User`},
+		{"quoted", `"Test User"`, `"Test User"`},
 	}
 
 	address := "test@example.com"
@@ -674,10 +702,8 @@ func TestV3NewEmail(t *testing.T) {
 		name  string
 		want  string
 	}{
-		{"unquoted", "Johnny", "\"Johnny\""},
-		{"double quoted", "\"Johnny\"", "\"Johnny\""},
-		{"empty", "", "\"\""},
-		{"empty quoted", "\"\"", "\"\""},
+		{"unquoted", `Test User`, `Test User`},
+		{"quoted", `"Test User"`, `"Test User"`},
 	}
 
 	address := "Johnny@rocket.io"

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -75,25 +75,45 @@ func TestV3AddAttachment(t *testing.T) {
 func TestV3SetFrom(t *testing.T) {
 	m := NewV3Mail()
 
-	address := "test@example.com"
-	name := "Test User"
-	e := NewEmail(name, address)
-	m.SetFrom(e)
+	testcases := []struct {
+		title string
+		name  string
+		want  string
+	}{
+		{"unquoted", "Test User", "\"Test User\""},
+		{"double quoted", "\"Test User\"", "\"Test User\""},
+	}
 
-	assert.Equal(t, name, m.From.Name, fmt.Sprintf("name should be %s, got %s", name, e.Name))
-	assert.Equal(t, address, m.From.Address, fmt.Sprintf("address should be %s, got %s", address, e.Address))
+	address := "test@example.com"
+	for _, tc := range testcases {
+		e := NewEmail(tc.name, address)
+		m.SetFrom(e)
+
+		assert.Equal(t, tc.want, m.From.Name, fmt.Sprintf("name should be %s, got %s", tc.want, e.Name))
+		assert.Equal(t, address, m.From.Address, fmt.Sprintf("address should be %s, got %s", address, e.Address))
+	}
 }
 
 func TestV3SetReplyTo(t *testing.T) {
 	m := NewV3Mail()
 
-	address := "test@example.com"
-	name := "Test User"
-	e := NewEmail(name, address)
-	m.SetReplyTo(e)
+	testcases := []struct {
+		title string
+		name  string
+		want  string
+	}{
+		{"unquoted", "Test User", "\"Test User\""},
+		{"double quoted", "\"Test User\"", "\"Test User\""},
+	}
 
-	assert.Equal(t, name, m.ReplyTo.Name, fmt.Sprintf("name should be %s, got %s", name, e.Name))
-	assert.Equal(t, address, m.ReplyTo.Address, fmt.Sprintf("address should be %s, got %s", address, e.Address))
+	address := "test@example.com"
+	for _, tc := range testcases {
+		e := NewEmail(tc.name, address)
+		m.SetReplyTo(e)
+
+		assert.Equal(t, tc.want, m.ReplyTo.Name, fmt.Sprintf("name should be %s, got %s", tc.want, e.Name))
+		assert.Equal(t, address, m.ReplyTo.Address, fmt.Sprintf("address should be %s, got %s", address, e.Address))
+	}
 }
 
 func TestV3SetTemplateID(t *testing.T) {
@@ -649,13 +669,24 @@ func TestV3NewSetting(t *testing.T) {
 }
 
 func TestV3NewEmail(t *testing.T) {
-	name := "Johnny"
+	testcases := []struct {
+		title string
+		name  string
+		want  string
+	}{
+		{"unquoted", "Johnny", "\"Johnny\""},
+		{"double quoted", "\"Johnny\"", "\"Johnny\""},
+		{"empty", "", "\"\""},
+		{"empty quoted", "\"\"", "\"\""},
+	}
+
 	address := "Johnny@rocket.io"
+	for _, tc := range testcases {
+		e := NewEmail(tc.name, address)
 
-	e := NewEmail(name, address)
-
-	assert.Equal(t, name, e.Name, fmt.Sprintf("Name should be %s, got %s", name, e.Name))
-	assert.Equal(t, address, e.Address, fmt.Sprintf("Address should be %s, got %s", address, e.Address))
+		assert.Equal(t, tc.want, e.Name, fmt.Sprintf("Name should be %s, got %s", tc.want, e.Name))
+		assert.Equal(t, address, e.Address, fmt.Sprintf("Address should be %s, got %s", address, e.Address))
+	}
 }
 
 func TestV3NewSingleEmail(t *testing.T) {


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

Fixes #352

### Checklist
- [ ] I confirm that the latest PR commit passes its Travis CI build.
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Surrounds names passed to `mail.NewEmail` with double quotes to comply with RFC5322's section on special characters.

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
