### PR TITLE
fix: use the last version of testify that works for older go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: go
 
 env:
+  - version=1.7
+  - version=1.8
+  - version=1.9
+  - version=1.10
+  - version=1.11
+  - version=1.12
   - version=1.13
   - version=1.14
   - version=latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,8 @@ WORKDIR /go/src/github.com/sendgrid/sendgrid-go
 COPY . .
 
 RUN make install
+
+# Use the last version of testify that works for older go versions, and then
+# re-install to update dependencies.
+RUN (cd /go/src/github.com/stretchr/testify && git checkout v1.6.0)
+RUN make install


### PR DESCRIPTION
Note that the fix only applies to the Docker image which is what's used for executing tests against multiple go versions