### PR TITLE
feat: Add support for more bypass settings

### DIFF
--- a/helpers/mail/mail_v3.go
+++ b/helpers/mail/mail_v3.go
@@ -72,11 +72,14 @@ type Asm struct {
 
 // MailSettings defines mail and spamCheck settings
 type MailSettings struct {
-	BCC                  *BccSetting       `json:"bcc,omitempty"`
-	BypassListManagement *Setting          `json:"bypass_list_management,omitempty"`
-	Footer               *FooterSetting    `json:"footer,omitempty"`
-	SandboxMode          *Setting          `json:"sandbox_mode,omitempty"`
-	SpamCheckSetting     *SpamCheckSetting `json:"spam_check,omitempty"`
+	BCC                         *BccSetting       `json:"bcc,omitempty"`
+	BypassListManagement        *Setting          `json:"bypass_list_management,omitempty"`
+	BypassSpamManagement        *Setting          `json:"bypass_spam_management,omitempty"`
+	BypassBounceManagement      *Setting          `json:"bypass_bounce_management,omitempty"`
+	BypassUnsubscribeManagement *Setting          `json:"bypass_unsubscribe_management,omitempty"`
+	Footer                      *FooterSetting    `json:"footer,omitempty"`
+	SandboxMode                 *Setting          `json:"sandbox_mode,omitempty"`
+	SpamCheckSetting            *SpamCheckSetting `json:"spam_check,omitempty"`
 }
 
 // TrackingSettings holds tracking settings and mail settings
@@ -420,6 +423,24 @@ func (m *MailSettings) SetBCC(bcc *BccSetting) *MailSettings {
 // SetBypassListManagement ...
 func (m *MailSettings) SetBypassListManagement(bypassListManagement *Setting) *MailSettings {
 	m.BypassListManagement = bypassListManagement
+	return m
+}
+
+// SetBypassSpamManagement ...
+func (m *MailSettings) SetBypassSpamManagement(bypassSpamManagement *Setting) *MailSettings {
+	m.BypassSpamManagement = bypassSpamManagement
+	return m
+}
+
+// SetBypassBounceManagement ...
+func (m *MailSettings) SetBypassBounceManagement(bypassBounceManagement *Setting) *MailSettings {
+	m.BypassBounceManagement = bypassBounceManagement
+	return m
+}
+
+// SetBypassUnsubscribeManagement ...
+func (m *MailSettings) SetBypassUnsubscribeManagement(bypassUnsubscribeManagement *Setting) *MailSettings {
+	m.BypassUnsubscribeManagement = bypassUnsubscribeManagement
 	return m
 }
 

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -455,6 +455,27 @@ func TestV3MailSettingsSetBypassListManagement(t *testing.T) {
 	assert.True(t, *m.BypassListManagement.Enable, "BypassListManagement should be enabled")
 }
 
+func TestV3MailSettingsSetBypassSpamManagement(t *testing.T) {
+	m := NewMailSettings().SetBypassSpamManagement(NewSetting(true))
+
+	assert.NotNil(t, m.BypassSpamManagement, "BypassSpamManagement should not be nil")
+	assert.True(t, *m.BypassSpamManagement.Enable, "BypassSpamManagement should be enabled")
+}
+
+func TestV3MailSettingsSetBypassBounceManagement(t *testing.T) {
+	m := NewMailSettings().SetBypassBounceManagement(NewSetting(true))
+
+	assert.NotNil(t, m.BypassBounceManagement, "BypassBounceManagement should not be nil")
+	assert.True(t, *m.BypassBounceManagement.Enable, "BypassBounceManagement should be enabled")
+}
+
+func TestV3MailSettingsSetBypassUnsubscribeManagement(t *testing.T) {
+	m := NewMailSettings().SetBypassUnsubscribeManagement(NewSetting(true))
+
+	assert.NotNil(t, m.BypassUnsubscribeManagement, "BypassUnsubscribeManagement should not be nil")
+	assert.True(t, *m.BypassUnsubscribeManagement.Enable, "BypassUnsubscribeManagement should be enabled")
+}
+
 func TestV3MailSettingsSetSandboxMode(t *testing.T) {
 	m := NewMailSettings().SetSandboxMode(NewSetting(true))
 


### PR DESCRIPTION
Adds support for the other bypass filters settings as documented here https://sendgrid.com/docs/ui/sending-email/index-suppressions/#bypass-filters-and-v3-mail-send

The code changes just follow the same style as `bypass_list_management` as it's a simple field setting. I updated the tests to show the new fields being set properly. Note: I didn't modify the examples since these 3 new filters are mutually exclusive with `bypass_list_management` so modifying the existing examples will make the request object incorrect.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
