### PR TITLE
chore: Remove mail.send helpers with on-behalf-of header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.txt
 sendgrid.env
 .vscode
 prism*
+**/.idea/**/*

--- a/USAGE.md
+++ b/USAGE.md
@@ -6004,7 +6004,7 @@ The `on-behalf-of` header allows you to make calls for a particular subuser thro
 useful for automating bulk updates or administering a subuser without changing authentication in your code.
 
 ## Note
-The v3/mail/send endpoint does not support the `on-behalf-of`. ([Source](
+The v3/mail/send endpoint does not support the `on-behalf-of` header. ([Source](
     https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/on-behalf-of-subuser
 ))
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -6000,20 +6000,20 @@ if err != nil {
 <a name="on-behalf-of"></a>
 # On-Behalf of Subuser
 
-The on-behalf-of header allows you to make calls for a particular subuser through the parent account; this can be useful for automating bulk updates or administering a subuser without changing authentication in your code.
-## With Mail Helper Class
+The `on-behalf-of` header allows you to make calls for a particular subuser through the parent account. This can be 
+useful for automating bulk updates or administering a subuser without changing authentication in your code.
+
+## Note
+The v3/mail/send endpoint does not support the `on-behalf-of`. ([Source](
+    https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/on-behalf-of-subuser
+))
 
 ```go
 
-client := sendgrid.NewSendClientSubuser(os.Getenv("SENDGRID_API_KEY"), "SUBUSER_USERNAME")
-
-```
-
-## Without Mail Helper Class
-
-```go
-
-request := sendgrid.GetRequestSubuser(os.Getenv("SENDGRID_API_KEY"), "/v3/mail/send", "https://api.sendgrid.com", "SUBUSER_USERNAME")
+request := sendgrid.GetRequestSubuser(
+	os.Getenv("SENDGRID_API_KEY"), "/v3/tracking_settings/subscription", 
+	"https://api.sendgrid.com", "SUBUSER_USERNAME",
+)
 
 ```
 

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -1,6 +1,8 @@
 package sendgrid
 
 import (
+	"strings"
+
 	"github.com/sendgrid/rest"
 )
 
@@ -21,6 +23,10 @@ func GetRequest(key, endpoint, host string) rest.Request {
 // GetRequestSubuser like GetRequest but with On-Behalf of Subuser
 // @return [Request] a default request object
 func GetRequestSubuser(key, endpoint, host, subuser string) rest.Request {
+	if strings.Contains(endpoint, "v3/mail/send") {
+		// TODO: Breaking change: Return an error instead of panicking
+		panic("cannot use on-behalf-of for v3/mail/send")
+	}
 	return createSendGridRequest(sendGridOptions{key, endpoint, host, subuser})
 }
 
@@ -44,14 +50,6 @@ func createSendGridRequest(sgOptions sendGridOptions) rest.Request {
 // NewSendClient constructs a new Twilio SendGrid client given an API key
 func NewSendClient(key string) *Client {
 	request := GetRequest(key, "/v3/mail/send", "")
-	request.Method = "POST"
-	return &Client{request}
-}
-
-// GetRequestSubuser like NewSendClient but with On-Behalf of Subuser
-// @return [Client]
-func NewSendClientSubuser(key, subuser string) *Client {
-	request := GetRequestSubuser(key, "/v3/mail/send", "", subuser)
 	request.Method = "POST"
 	return &Client{request}
 }

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -1,8 +1,6 @@
 package sendgrid
 
 import (
-	"strings"
-
 	"github.com/sendgrid/rest"
 )
 
@@ -23,10 +21,6 @@ func GetRequest(key, endpoint, host string) rest.Request {
 // GetRequestSubuser like GetRequest but with On-Behalf of Subuser
 // @return [Request] a default request object
 func GetRequestSubuser(key, endpoint, host, subuser string) rest.Request {
-	if strings.Contains(endpoint, "v3/mail/send") {
-		// TODO: Breaking change: Return an error instead of panicking
-		panic("cannot use on-behalf-of for v3/mail/send")
-	}
 	return createSendGridRequest(sendGridOptions{key, endpoint, host, subuser})
 }
 

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sendgrid/rest"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLicenseYear(t *testing.T) {
@@ -83,23 +82,6 @@ func TestGetRequestSubuser(t *testing.T) {
 	}
 
 	ShouldHaveHeaders(&request, t)
-}
-
-func TestGetRequestSubUser_ShouldRejectMailSend(t *testing.T) {
-	// https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/on-behalf-of-subuser
-	// > The on-behalf-of header does not work with the mail.send API.
-
-	assertPanicked := func() {
-		rec := recover()
-		err, ok := rec.(string)
-		require.True(t, ok, "Recover should have returned error")
-		assert.NotEqual(t, "", err, "Should have panicked for /v3/mail/send")
-	}
-	defer assertPanicked()
-
-	_ = GetRequestSubuser(
-		"any API key", "/v3/mail/send", "https://example.com", "subuserUsername",
-	)
 }
 
 func getRequest(endpoint string) rest.Request {

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sendgrid/rest"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLicenseYear(t *testing.T) {
@@ -84,9 +85,21 @@ func TestGetRequestSubuser(t *testing.T) {
 	ShouldHaveHeaders(&request, t)
 }
 
-func TestNewSendClientSubuser(t *testing.T) {
-	client := NewSendClientSubuser("API_KEY", "subuserUsername")
-	ShouldHaveHeaders(&client.Request, t)
+func TestGetRequestSubUser_ShouldRejectMailSend(t *testing.T) {
+	// https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/on-behalf-of-subuser
+	// > The on-behalf-of header does not work with the mail.send API.
+
+	assertPanicked := func() {
+		rec := recover()
+		err, ok := rec.(string)
+		require.True(t, ok, "Recover should have returned error")
+		assert.NotEqual(t, "", err, "Should have panicked for /v3/mail/send")
+	}
+	defer assertPanicked()
+
+	_ = GetRequestSubuser(
+		"any API key", "/v3/mail/send", "https://example.com", "subuserUsername",
+	)
 }
 
 func getRequest(endpoint string) rest.Request {


### PR DESCRIPTION
The sendgrid documentation (and my own findings) say that the mail.send endpoint
does not support using the `on-behalf-of` header.

![image](https://user-images.githubusercontent.com/8963131/126390327-9e8df3f1-ed86-4f02-9fe5-2ec3e4dc74bb.png)
[Documentation](
https://docs.sendgrid.com/api-reference/how-to-use-the-sendgrid-v3-api/on-behalf-of-subuser
)

Providing the `NewSendClientSubuser` in this SDK causes wasted time because it
sets the expectation that this is possible when it is not.

I also added guards to the `GetRequestSubuser` function to prevent people from
using it with the mail.send endpoint.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

A short description of what this PR does.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified