### PR TITLE
chore: add support for 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 env:
 - version=1.14
 - version=1.15
+- version=1.16
 script:
 - if [[ "$TRAVIS_BRANCH" == "main"  ||  "$TRAVIS_BRANCH" == "travis" ]] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG version=latest
 FROM golang:$version
 
 ENV GODEBUG 'x509ignoreCN=0'
+ENV GO111MODULE 'off'
 
 COPY prism/prism/nginx/cert.crt /usr/local/share/ca-certificates/cert.crt
 RUN update-ca-certificates

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We appreciate your continued support, thank you!
 
 ## Prerequisites
 
-- Go version 1.7
+- Go version 1.14
 - The Twilio SendGrid service, starting at the [free level](https://sendgrid.com/free?source=sendgrid-go), to send up to 40,000 emails for the first 30 days, then send 100 emails/day free forever or check out [our pricing](https://sendgrid.com/pricing?source=sendgrid-go).
 
 ## Setup Environment Variables

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We appreciate your continued support, thank you!
 
 ## Prerequisites
 
-- Go version 1.14
+- Go version 1.14, 1.15 or 1.16
 - The Twilio SendGrid service, starting at the [free level](https://sendgrid.com/free?source=sendgrid-go), to send up to 40,000 emails for the first 30 days, then send 100 emails/day free forever or check out [our pricing](https://sendgrid.com/pricing?source=sendgrid-go).
 
 ## Setup Environment Variables


### PR DESCRIPTION
Add travis tests against v1.16 (without supporting go modules)