### PR TITLE
fix: inbound.Parse panics when Content-Type is not multipart

### DIFF
--- a/helpers/inbound/inbound.go
+++ b/helpers/inbound/inbound.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"mime"
 	"mime/multipart"
+	"mime/quotedprintable"
 	"net/http"
 	"strings"
 )
@@ -166,6 +167,26 @@ func (email *ParsedEmail) parseRawEmail(rawEmail string) error {
 	raw, err := parseMultipart(strings.NewReader(sections[1]), email.Headers["Content-Type"])
 	if err != nil {
 		return err
+	}
+
+	// if Content-Type is not multipart just set the whole email
+	if raw == nil {
+		if len(sections) < 2 {
+			return nil
+		}
+
+		wholeEmail := sections[1]
+		// decode if needed
+		if email.Headers["Content-Transfer-Encoding"] == "quoted-printable" {
+			decoded, err := ioutil.ReadAll(quotedprintable.NewReader(strings.NewReader(wholeEmail)))
+			if err != nil {
+				return fmt.Errorf("failed to decode quoted-printable: %w", err)
+			}
+			wholeEmail = string(decoded)
+		}
+
+		email.Body[email.Headers["Content-Type"]] = wholeEmail
+		return nil
 	}
 
 	for {


### PR DESCRIPTION
Resolves https://github.com/sendgrid/opensource/issues/28

# Fixes #

Fixes `inbound.Parse` that currently panics when the Content-Type of the email is not `multipart/...`.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
