### PR TITLE
feat: gzip mail body when content-encoding is set to gzip

### DIFF
--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -1602,6 +1602,156 @@ func Test_test_mail_batch__batch_id__get(t *testing.T) {
 	assert.Equal(t, 200, response.StatusCode, "Wrong status code returned")
 }
 
+func Test_test_send_client_with_mail_body_compression_enabled(t *testing.T) {
+	apiKey := "SENDGRID_API_KEY"
+	client := NewSendClient(apiKey)
+	client.Headers["Content-Encoding"] = "gzip"
+
+	emailBytes := []byte(` {
+		"asm": {
+			"group_id": 1,
+			"groups_to_display": [
+			1,
+			2,
+			3
+			]
+		},
+		"attachments": [
+			{
+			"content": "[BASE64 encoded content block here]",
+			"content_id": "ii_139db99fdb5c3704",
+			"disposition": "inline",
+			"filename": "file1.jpg",
+			"name": "file1",
+			"type": "jpg"
+			}
+		],
+		"batch_id": "[YOUR BATCH ID GOES HERE]",
+		"categories": [
+			"category1",
+			"category2"
+		],
+		"content": [
+			{
+			"type": "text/html",
+			"value": "<html><p>Hello, world!</p><img src=[CID GOES HERE]></img></html>"
+			}
+		],
+		"custom_args": {
+			"New Argument 1": "New Value 1",
+			"activationAttempt": "1",
+			"customerAccountNumber": "[CUSTOMER ACCOUNT NUMBER GOES HERE]"
+		},
+		"from": {
+			"email": "sam.smith@example.com",
+			"name": "Sam Smith"
+		},
+		"headers": {},
+		"ip_pool_name": "[YOUR POOL NAME GOES HERE]",
+		"mail_settings": {
+			"bcc": {
+			"email": "ben.doe@example.com",
+			"enable": true
+			},
+			"bypass_list_management": {
+			"enable": true
+			},
+			"footer": {
+			"enable": true,
+			"html": "<p>Thanks</br>The Twilio SendGrid Team</p>",
+			"text": "Thanks,/n The Twilio SendGrid Team"
+			},
+			"sandbox_mode": {
+			"enable": false
+			},
+			"spam_check": {
+			"enable": true,
+			"post_to_url": "http://example.com/compliance",
+			"threshold": 3
+			}
+		},
+		"personalizations": [
+			{
+			"bcc": [
+				{
+				"email": "sam.doe@example.com",
+				"name": "Sam Doe"
+				}
+			],
+			"cc": [
+				{
+				"email": "jane.doe@example.com",
+				"name": "Jane Doe"
+				}
+			],
+			"custom_args": {
+				"New Argument 1": "New Value 1",
+				"activationAttempt": "1",
+				"customerAccountNumber": "[CUSTOMER ACCOUNT NUMBER GOES HERE]"
+			},
+			"headers": {
+				"X-Accept-Language": "en",
+				"X-Mailer": "MyApp"
+			},
+			"send_at": 1409348513,
+			"subject": "Hello, World!",
+			"substitutions": {
+				"id": "substitutions",
+				"type": "object"
+			},
+			"to": [
+				{
+				"email": "john.doe@example.com",
+				"name": "John Doe"
+				}
+			]
+			}
+		],
+		"reply_to": {
+			"email": "sam.smith@example.com",
+			"name": "Sam Smith"
+		},
+		"send_at": 1409348513,
+		"subject": "Hello, World!",
+		"template_id": "[YOUR TEMPLATE ID GOES HERE]",
+		"tracking_settings": {
+			"click_tracking": {
+			"enable": true,
+			"enable_text": true
+			},
+			"ganalytics": {
+			"enable": true,
+			"utm_campaign": "[NAME OF YOUR REFERRER SOURCE]",
+			"utm_content": "[USE THIS SPACE TO DIFFERENTIATE YOUR EMAIL FROM ADS]",
+			"utm_medium": "[NAME OF YOUR MARKETING MEDIUM e.g. email]",
+			"utm_name": "[NAME OF YOUR CAMPAIGN]",
+			"utm_term": "[IDENTIFY PAID KEYWORDS HERE]"
+			},
+			"open_tracking": {
+			"enable": true,
+			"substitution_tag": "%opentrack"
+			},
+			"subscription_tracking": {
+			"enable": true,
+			"html": "If you would like to unsubscribe and stop receiving these emails <% clickhere %>.",
+			"substitution_tag": "<%click here%>",
+			"text": "If you would like to unsubscribe and stop receiving these emails <% click here %>."
+			}
+		}
+	}`)
+	email := &mail.SGMailV3{}
+	err := json.Unmarshal(emailBytes, email)
+	assert.Nil(t, err, fmt.Sprintf("Unmarshal error: %v", err))
+	client.Request.Headers["X-Mock"] = "202"
+	response, err := client.Send(email)
+	if err != nil {
+		t.Log(err)
+	}
+	t.Log(response)
+	assert.Equal(t, 202, response.StatusCode, "Wrong status code returned")
+
+}
+
 func Test_test_send_client(t *testing.T) {
 	apiKey := "SENDGRID_APIKEY"
 	client := NewSendClient(apiKey)


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

[Mail body compression](https://docs.sendgrid.com/api-reference/mail-send/mail-send#mail-body-compression) is supported on V3 api. This patch added the support that when a client sets the content-encoding header to gzip, send compresses the mail body with gzip.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

