### PR TITLE
chore: removed SetHost and shifted SetDataResidency to sendgrid.go

### DIFF
--- a/sendgrid.go
+++ b/sendgrid.go
@@ -1,7 +1,9 @@
 package sendgrid
 
 import (
+	"errors"
 	"github.com/sendgrid/rest"
+	"net/url"
 )
 
 // sendGridOptions for CreateRequest
@@ -10,6 +12,12 @@ type sendGridOptions struct {
 	Endpoint string
 	Host     string
 	Subuser  string
+}
+
+// sendgrid host map for different regions
+var allowedRegionsHostMap = map[string]string{
+	"eu":     "https://api.eu.sendgrid.com",
+	"global": "https://api.sendgrid.com",
 }
 
 // GetRequest
@@ -46,4 +54,37 @@ func NewSendClient(key string) *Client {
 	request := GetRequest(key, "/v3/mail/send", "")
 	request.Method = "POST"
 	return &Client{request}
+}
+
+// extractEndpoint extracts the endpoint from a baseURL
+func extractEndpoint(link string) (string, error) {
+	parsedURL, err := url.Parse(link)
+	if err != nil {
+		return "", err
+	}
+
+	return parsedURL.Path, nil
+}
+
+// SetDataResidency modifies the host as per the region
+/*
+ * This allows support for global and eu regions only. This set will likely expand in the future.
+ * Global should be the default
+ * Global region means the message should be sent through:
+ * HTTP: api.sendgrid.com
+ * EU region means the message should be sent through:
+ * HTTP: api.eu.sendgrid.com
+ */
+// @return [Request] the modified request object
+func SetDataResidency(request rest.Request, region string) (rest.Request, error) {
+	regionalHost, present := allowedRegionsHostMap[region]
+	if !present {
+		return request, errors.New("error: region can only be \"eu\" or \"global\"")
+	}
+	endpoint, err := extractEndpoint(request.BaseURL)
+	if err != nil {
+		return request, err
+	}
+	request.BaseURL = regionalHost + endpoint
+	return request, nil
 }

--- a/sendgrid_test.go
+++ b/sendgrid_test.go
@@ -102,15 +102,6 @@ func TestSetDataResidencyOverrideHost(t *testing.T) {
 	assert.Equal(t, "https://api.eu.sendgrid.com", request.BaseURL, "Host not correct as per the region")
 }
 
-func TestSetDataResidencyOverrideDataResidency(t *testing.T) {
-	request := GetRequest("API_KEY", "", "")
-	request, err := SetDataResidency(request, "eu")
-	assert.Nil(t, err)
-	request, err = SetHost(request, "https://test.api.com")
-	assert.Nil(t, err)
-	assert.Equal(t, "https://test.api.com", request.BaseURL, "Host not correct as per the region")
-}
-
 func TestSetDataResidencyIncorrectRegion(t *testing.T) {
 	request := GetRequest("API_KEY", "", "")
 	_, err := SetDataResidency(request, "foo")


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

1. Removed public SetHost() as it is not required for Go [SetDataResidency does exactly the same thing]
2. Shifted SetDataResidency() to sendgrid.go since it is specific to that only. Earlier it was in base_interface.go which means if someone creates a twilio_email request, then also they would be able to access SetDataResidency() and overrides host. But that doesn't make sense since it is specific to sendgrid only.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
