### PR TITLE
feat: add mail_v3 functionality for reply_to_list

### DIFF
--- a/helpers/mail/mail_v3.go
+++ b/helpers/mail/mail_v3.go
@@ -37,6 +37,7 @@ type SGMailV3 struct {
 	MailSettings     *MailSettings      `json:"mail_settings,omitempty"`
 	TrackingSettings *TrackingSettings  `json:"tracking_settings,omitempty"`
 	ReplyTo          *Email             `json:"reply_to,omitempty"`
+	ReplyToList      []*Email           `json:"reply_to_list,omitempty"`
 }
 
 // Personalization holds mail body struct
@@ -229,6 +230,12 @@ func (s *SGMailV3) SetFrom(e *Email) *SGMailV3 {
 // SetReplyTo ...
 func (s *SGMailV3) SetReplyTo(e *Email) *SGMailV3 {
 	s.ReplyTo = e
+	return s
+}
+
+// SetReplyToList ...
+func (s *SGMailV3) SetReplyToList(e []*Email) *SGMailV3 {
+	s.ReplyToList = e
 	return s
 }
 

--- a/helpers/mail/mail_v3_test.go
+++ b/helpers/mail/mail_v3_test.go
@@ -96,6 +96,17 @@ func TestV3SetReplyTo(t *testing.T) {
 	assert.Equal(t, address, m.ReplyTo.Address, fmt.Sprintf("address should be %s, got %s", address, e.Address))
 }
 
+func TestV3SetReplyToList(t *testing.T) {
+	m := NewV3Mail()
+	replyTos := []*Email{
+		NewEmail("Example User", "test@example.com"),
+		NewEmail("Example User", "test@example.com"),
+	}
+	m.SetReplyToList(replyTos)
+
+	assert.Equal(t, len(replyTos), len(m.ReplyToList), fmt.Sprintf("length of To should be %d, got %d", len(replyTos), len(m.ReplyToList)))
+}
+
 func TestV3SetTemplateID(t *testing.T) {
 	m := NewV3Mail()
 


### PR DESCRIPTION
Add reply_to_list functionality. It just implements a feature that is available on api but not yet on the SDK (and should).

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
