### PR TITLE
chore: fixed failed test cases due to go upgrade

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -42,6 +42,11 @@ jobs:
           echo "GOBIN=$HOME/bin" >> $GITHUB_ENV
           echo "GO111MODULE=off" >> $GITHUB_ENV
 
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
+
       - name: Run Tests
         run: make test-docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG version=1.21.11
-FROM golang:$version
+FROM golang:1.21.11
 
 ENV GO111MODULE 'off'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG version=latest
+ARG version=1.21.11
 FROM golang:$version
 
 ENV GO111MODULE 'off'

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2023, Twilio SendGrid, Inc. <help@twilio.com>
+Copyright (C) 2024, Twilio SendGrid, Inc. <help@twilio.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
# Fixes #
1. As of [Go 1.22](https://go.dev/doc/go1.22#go-command), “go get is no longer supported outside of a module”, Thus it was failing go get command.
**Failure:** 
```
0.256 go get -t -v ./...
0.258 go: modules disabled by GO111MODULE=off; see 'go help modules'
```
**Link**: https://github.com/sendgrid/sendgrid-go/actions/runs/9859530453/job/27223508248#step:6:231

**Issue**: https://github.com/golang/go/issues/66080

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
