### PR TITLE
docs: update deprecated io.ReadFile with os.ReadFile

### DIFF
--- a/use-cases/attachments-with-mailer-helper.md
+++ b/use-cases/attachments-with-mailer-helper.md
@@ -8,7 +8,6 @@ import (
   "log"
   "os"
   "encoding/base64"
-  "io/ioutil"
   "github.com/sendgrid/sendgrid-go"
   "github.com/sendgrid/sendgrid-go/helpers/mail"
 )
@@ -34,7 +33,7 @@ func main() {
   
   // read/attach .txt file
   a_txt := mail.NewAttachment()
-  dat, err := io.ReadFile("testing.txt")
+  dat, err := os.ReadFile("testing.txt")
   if err != nil {
     fmt.Println(err)
   }
@@ -46,7 +45,7 @@ func main() {
   
   // read/attach .pdf file
   a_pdf := mail.NewAttachment()
-  dat, err = io.ReadFile("testing.pdf")
+  dat, err = os.ReadFile("testing.pdf")
   if err != nil {
     fmt.Println(err)
   }
@@ -58,7 +57,7 @@ func main() {
 
   // read/attach inline .jpg file
   a_jpg := mail.NewAttachment()
-  dat, err = io.ReadFile("testing.jpg")
+  dat, err = os.ReadFile("testing.jpg")
   if err != nil {
     fmt.Println(err)
   }


### PR DESCRIPTION
Replaced io.ReadFile calls with os.ReadFile in use-cases example
- As of Go 1.16, this function simply calls os.ReadFile: https://pkg.go.dev/io/ioutil#ReadFile

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-go/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
